### PR TITLE
Use ioutil package for backwards compatibility

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"time"
 )
@@ -48,7 +48,7 @@ func (c *Client) getParsed(r *http.Request, data interface{}) error {
 	body := PaginatedBody{
 		Data: &data,
 	}
-	rawBody, err := io.ReadAll(resp.Body)
+	rawBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/RedHatInsights/rbac-client-go
 
-go 1.16
+go 1.15
 
-require github.com/stretchr/testify v1.7.0 // indirect
+require github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
We discovered some clients that still use Go 1.15. This is a simple backwards compatibility fix to allow them to still import this package.